### PR TITLE
AZ-104: Change region in AZ-104 labs

### DIFF
--- a/bicep/az-104/az-104-lab4.bicep
+++ b/bicep/az-104/az-104-lab4.bicep
@@ -1,4 +1,4 @@
-param location string = 'australiaeast'
+param location string = 'australiasoutheast'
 param resourceGroupName string = 'az104-rg5'
 
 module coreServicesVnet '../modules/vnet.bicep' = {


### PR DESCRIPTION
This pull request includes a single change to the `bicep/az-104/az-104-lab4.bicep` file. The default value of the `location` parameter was updated from `'australiaeast'` to `'australiasoutheast'` to reflect a change in the target deployment region.